### PR TITLE
Refactor log file path to use pathlib

### DIFF
--- a/src/auto_stash/stash_watcher.py
+++ b/src/auto_stash/stash_watcher.py
@@ -8,15 +8,16 @@ from typing import List, Tuple
 
 APP_NAME = "GitAutoStash"
 DEFAULT_INTERVAL = 20 # second
-LOG_FILE = os.path.join(os.path.dirname(__file__), "..", "logs", "auto_stash.log")
+# Use pathlib for cross-platform path handling and resolve the log file location
+LOG_FILE = Path(__file__).resolve().parent.parent / "logs" / "auto_stash.log"
 
 
 def log(msg: str):
     ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(LOG_FILE, "a", encoding="utf-8") as f:
+    with LOG_FILE.open("a", encoding="utf-8") as f:
         f.write(f"[{ts}] {msg}\n")
 
     print(f"[{ts}] {msg}")


### PR DESCRIPTION
## Summary
- Use pathlib to build and manage the log file path
- Ensure log directory exists with pathlib's `mkdir`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfdb59c164832490addf0a6ba5cd10